### PR TITLE
Guard listable nulls in workflow rows

### DIFF
--- a/app/src/main/java/com/teraim/fieldapp/dynamic/workflow_realizations/WF_ListEntry.java
+++ b/app/src/main/java/com/teraim/fieldapp/dynamic/workflow_realizations/WF_ListEntry.java
@@ -6,6 +6,7 @@ import android.view.View;
 import com.teraim.fieldapp.dynamic.types.Variable;
 import com.teraim.fieldapp.dynamic.workflow_abstracts.Listable;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +93,9 @@ public abstract class WF_ListEntry extends WF_Widget implements Listable,Compara
 	}
 
 	public Map<String,String> getKeyChain() {
+		if (myVar == null) {
+			return Collections.emptyMap();
+		}
 		return myVar.getKeyChain();
 	}
 	

--- a/app/src/main/java/com/teraim/fieldapp/dynamic/workflow_realizations/WF_Simple_Cell_Widget.java
+++ b/app/src/main/java/com/teraim/fieldapp/dynamic/workflow_realizations/WF_Simple_Cell_Widget.java
@@ -110,11 +110,13 @@ public class WF_Simple_Cell_Widget extends WF_Widget implements WF_Cell, EventLi
 		// Called when the user selects a contextual menu item
 		@Override
 		public boolean onActionItemClicked(final ActionMode mode, MenuItem item) {
-			List<String> row = null;
-			String msg = "";
-			row = myVariable.getBackingDataSet();
+        if (myVariable == null) {
+            return false;
+        }
+        List<String> row = myVariable.getBackingDataSet();
+        String msg = "";
 
-			switch (item.getItemId()) {
+        switch (item.getItemId()) {
 				case R.id.menu_goto:
 					if (row != null) {
 						String url = al.getUrl(row);
@@ -246,29 +248,31 @@ public class WF_Simple_Cell_Widget extends WF_Widget implements WF_Cell, EventLi
 	}
 
 	@Override
-		public Map<String, String> getKeyHash() {
-			return null;
-		}
+    public Map<String, String> getKeyHash() {
+        return myHash;
+    }
 
-		@Override
-		public Set<Variable> getAssociatedVariables() {
-			if (myVariable!=null) {
-				Set<Variable> ret = new HashSet<Variable>();
-				ret.add(myVariable);
-				return ret;
-			}
-			return null;
+    @Override
+    public Set<Variable> getAssociatedVariables() {
+        if (myVariable!=null) {
+            Set<Variable> ret = new HashSet<>();
+            ret.add(myVariable);
+            return ret;
+        }
+        return new HashSet<>();
 
-		}
+    }
 
 
-		@Override
-		public void onEvent(Event e) {
-			if (e.getProvider().equals(Constants.SYNC_ID)) {
-				String val = myVariable.getValue();
-				myCheckBox.setChecked(val!=null && val.equals("true"));
-			}
-		}
+    @Override
+    public void onEvent(Event e) {
+        if (e.getProvider().equals(Constants.SYNC_ID)) {
+            if (myVariable != null) {
+                String val = myVariable.getValue();
+                myCheckBox.setChecked(val!=null && val.equals("true"));
+            }
+        }
+    }
 
 		@Override
 		public String getName() {

--- a/app/src/main/java/com/teraim/fieldapp/dynamic/workflow_realizations/WF_Table_Row.java
+++ b/app/src/main/java/com/teraim/fieldapp/dynamic/workflow_realizations/WF_Table_Row.java
@@ -15,6 +15,7 @@ import com.teraim.fieldapp.dynamic.workflow_abstracts.Listable;
 import com.teraim.fieldapp.utils.Tools;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -109,7 +110,7 @@ public class WF_Table_Row extends WF_Widget implements Listable,Comparable<Lista
 		if (myColumns!=null && !myColumns.isEmpty()) {
 			return myColumns.get(0).getAssociatedVariables();
 		}
-		return null;
+		return Collections.emptySet();
 	}
 
 
@@ -231,8 +232,7 @@ public class WF_Table_Row extends WF_Widget implements Listable,Comparable<Lista
 	}
 	@Override
 	public Map<String, String> getKeyChain() {
-		// TODO Auto-generated method stub
-		return null;
+		return Collections.emptyMap();
 	}
 
 

--- a/app/src/main/java/com/teraim/fieldapp/dynamic/workflow_realizations/WF_Table_Row_Recycle.java
+++ b/app/src/main/java/com/teraim/fieldapp/dynamic/workflow_realizations/WF_Table_Row_Recycle.java
@@ -21,6 +21,7 @@ import com.teraim.fieldapp.dynamic.workflow_abstracts.Listable;
 import com.teraim.fieldapp.utils.Tools;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -333,7 +334,7 @@ public class WF_Table_Row_Recycle extends WF_Widget implements Listable,Comparab
 	@Override public long getTimeStamp() { return 0; }
 	@Override public boolean hasValue() { if (myColumns==null || myColumns.isEmpty()) return false; for (WF_Cell w:myColumns) if (w.hasValue()) return true; return false; }
 	@Override public void refresh() { if (myColumns==null) return ; for (WF_Cell w:myColumns) w.refresh(); }
-	@Override public Set<Variable> getAssociatedVariables() { if (myColumns!=null && !myColumns.isEmpty()) { return myColumns.get(0).getAssociatedVariables(); } return null; }
+	@Override public Set<Variable> getAssociatedVariables() { if (myColumns!=null && !myColumns.isEmpty()) { return myColumns.get(0).getAssociatedVariables(); } return Collections.emptySet(); }
 	@Override public int compareTo(Listable other) { return this.getLabel().compareTo(other.getLabel()); }
 
 	public View addNoClickHeaderCell(String label, String backgroundColor, String textColor) {
@@ -370,7 +371,7 @@ public class WF_Table_Row_Recycle extends WF_Widget implements Listable,Comparab
 	@Override
 	public String getLabel() { if (al == null) { return "*ConfigErr*"; } return al.getEntryLabel(myRow); }
 	@Override public String getKey() { return getLabel(); }
-	@Override public Map<String, String> getKeyChain() { return null; }
+	@Override public Map<String, String> getKeyChain() { return Collections.emptyMap(); }
 
 	public boolean hasAnyCheckedNonAggregateSimpleCell(List<PageWithTable.ColumnDefinition> globalColumnDefinitions) {
 		if (myColumns == null || myColumns.isEmpty() || globalColumnDefinitions == null) return false;


### PR DESCRIPTION
## Summary
- avoid null keychains and variable sets in listable row implementations
- guard simple cell widget actions against missing variables
- reduce NPE risk during list/table filtering and sync refresh

## Test plan
- [ ] Not run (logic-only change)